### PR TITLE
rabbit: set interval max for auto retry

### DIFF
--- a/oslo_messaging/_drivers/impl_rabbit.py
+++ b/oslo_messaging/_drivers/impl_rabbit.py
@@ -684,6 +684,7 @@ class Connection(object):
                 errback=on_error,
                 interval_start=self.interval_start or 1,
                 interval_step=self.interval_stepping,
+                interval_max=self.interval_max,
                 on_revive=on_reconnection,
             )
             ret, channel = autoretry_method()


### PR DESCRIPTION
interval_max value is now correctly passed on to autoretry (was unused before)